### PR TITLE
Add the stage into the Jenkinsfile lambdaTests call.

### DIFF
--- a/Jenkinsfile-test
+++ b/Jenkinsfile-test
@@ -1,6 +1,9 @@
 library("tdr-jenkinslib")
 
 lambdaTests(
+  // Hard-code stage, since it is arbitrary in the lambdaTests
+  // function, which publishes the code to the management account
+  stage: "intg",
   libraryName: "sign-cookies",
   deployJobName: "TDR Sign Cookies Lambda Deploy"
 )


### PR DESCRIPTION
I thought this wasn't used but it is because it's needed for the role
which runs the container to deploy the lambda.
