### PR TITLE
Remove the requestContext from the case class.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/signcookies/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/signcookies/Lambda.scala
@@ -61,7 +61,7 @@ class Lambda extends RequestStreamHandler {
       lambdaInput <- IO.fromEither(decode[LambdaInput](rawInput))
       config <- ConfigSource.default.loadF[IO, Config].map(decryptVariables)
       validatedToken <- validateToken(config.authUrl, lambdaInput.headers.Authorization.stripPrefix("Bearer "))
-      cookies <- responseCreator.createCookies(validatedToken.userId, config, lambdaInput.requestContext.identity.sourceIp)
+      cookies <- responseCreator.createCookies(validatedToken.userId, config)
       response <- responseCreator.createResponse(cookies, lambdaInput.headers.origin, config)
       _ <- write(output, response.asJson.printWith(noSpaces))
     } yield response
@@ -77,11 +77,7 @@ class Lambda extends RequestStreamHandler {
 object Lambda {
   case class Headers(Authorization: String, origin: String)
 
-  case class LambdaIdentity(sourceIp: String)
-
-  case class LambdaRequestContext(identity: LambdaIdentity)
-
-  case class LambdaInput(headers: Headers, requestContext: LambdaRequestContext)
+  case class LambdaInput(headers: Headers)
 
   case class ResponseHeaders(`Access-Control-Allow-Origin`: String, `Access-Control-Allow-Credentials`: String)
 

--- a/src/main/scala/uk/gov/nationalarchives/signcookies/LambdaRunner.scala
+++ b/src/main/scala/uk/gov/nationalarchives/signcookies/LambdaRunner.scala
@@ -14,11 +14,6 @@ object LambdaRunner extends App {
        |  "headers": {
        |    "Authorization": "Bearer $accessToken",
        |    "origin": "http://localhost:9000"
-       |  },
-       |  "requestContext": {
-       |    "identity": {
-       |      "sourceIp": "1.2.3.4"
-       |    }
        |  }
        |}""".stripMargin
   val inputStream = new ByteArrayInputStream(input.getBytes)

--- a/src/main/scala/uk/gov/nationalarchives/signcookies/ResponseCreator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/signcookies/ResponseCreator.scala
@@ -9,7 +9,6 @@ import uk.gov.nationalarchives.signcookies.Lambda.{Config, LambdaResponse, Respo
 
 import java.security.KeyFactory
 import java.security.spec.PKCS8EncodedKeySpec
-import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.{Base64, Date, UUID}
 
@@ -34,7 +33,7 @@ class ResponseCreator(timeUtils: TimeUtils) {
     IO(response)
   }
 
-  def createCookies(userId: UUID, config: Config, sourceIp: String): IO[CookiesForCustomPolicy] = {
+  def createCookies(userId: UUID, config: Config): IO[CookiesForCustomPolicy] = {
     val decodedCert = Base64.getDecoder.decode(config.privateKey)
     val keySpec = new PKCS8EncodedKeySpec(decodedCert)
     val keyFactory = KeyFactory.getInstance("RSA")
@@ -46,7 +45,7 @@ class ResponseCreator(timeUtils: TimeUtils) {
     val keyPairId = config.keyPairId
     val activeFrom = Date.from(timeUtils.now())
     val expiresOn = Date.from(timeUtils.now().plus(30, ChronoUnit.MINUTES))
-    val ipRange = s"$sourceIp/32"
+    val ipRange = s"0.0.0.0/0"
 
     IO {
       CloudFrontCookieSigner.getCookiesForCustomPolicy(

--- a/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTestUtils.scala
@@ -70,7 +70,7 @@ object LambdaTestUtils {
        |  },
        |  "requestContext": {
        |    "identity": {
-       |      "sourceIp": "1.2.3.4"
+       |      "sourceIp": "0.0.0.0"
        |    }
        |  }
        |}""".stripMargin


### PR DESCRIPTION
We were getting the source IP from the incoming requestContext object and then adding this to the restrictions in the Cloudfront policy. The problem is that the source IP is the IP from Cloudfront and not the client IP so we can't use this.

There are ways around this which I've put in [this ticket](https://national-archives.atlassian.net/browse/TDR-1397) in the backlog. For now, I'll leave the IP restrictions open.
