### PR TITLE
Remove IP and activeFrom from the policy.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/signcookies/ResponseCreator.scala
+++ b/src/main/scala/uk/gov/nationalarchives/signcookies/ResponseCreator.scala
@@ -43,9 +43,9 @@ class ResponseCreator(timeUtils: TimeUtils) {
     val protocol = Protocol.https
     val distributionDomain = config.uploadDomain
     val keyPairId = config.keyPairId
-    val activeFrom = Date.from(timeUtils.now())
-    val expiresOn = Date.from(timeUtils.now().plus(30, ChronoUnit.MINUTES))
-    val ipRange = s"0.0.0.0/0"
+    val activeFrom = null
+    val expiresOn = Date.from(timeUtils.now().plus(24, ChronoUnit.HOURS))
+    val ipRange = null
 
     IO {
       CloudFrontCookieSigner.getCookiesForCustomPolicy(


### PR DESCRIPTION
activeFrom was causing us problems, mainly with the e2e tests where the
requests were being made very quickly. There's no reason I can see to
keep it in so I've removed it.

I've also removed the ipRange from the policy as it's already set to
fully open, there's no need to keep it.
