### PR TITLE
Handle incoming Origin header.

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/signcookies/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/signcookies/Lambda.scala
@@ -55,7 +55,7 @@ class Lambda extends RequestStreamHandler {
   }
 
   override def handleRequest(input: InputStream, output: OutputStream, context: Context): Unit = {
-    val rawInput = Source.fromInputStream(input).mkString
+    val rawInput = Source.fromInputStream(input).mkString.replace("\"Origin\"", "\"origin\"")
     val responseCreator = ResponseCreator(new TimeUtilsImpl())
     val response = for {
       _ <- IO.println(rawInput)

--- a/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTest.scala
@@ -66,4 +66,14 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
 
     decode[LambdaResponse](byteArrayCaptor.getValue.map(_.toChar).mkString).toOption.get.statusCode should equal(200)
   }
+
+  "the lambda" should "does not error if the origin header has an upper case first letter" in {
+    val accessToken = createAccessToken(UUID.randomUUID().some)
+    val inputStream = getInputStream(accessToken, originKey = "Origin")
+    val byteArrayCaptor: ArgumentCaptor[Array[Byte]] = ArgumentCaptor.forClass(classOf[Array[Byte]])
+
+    new Lambda().handleRequest(inputStream, outputStream(byteArrayCaptor), null)
+
+    decode[LambdaResponse](byteArrayCaptor.getValue.map(_.toChar).mkString).toOption.get.statusCode should equal(200)
+  }
 }

--- a/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTest.scala
+++ b/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTest.scala
@@ -67,7 +67,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     decode[LambdaResponse](byteArrayCaptor.getValue.map(_.toChar).mkString).toOption.get.statusCode should equal(200)
   }
 
-  "the lambda" should "does not error if the origin header has an upper case first letter" in {
+  "the lambda" should "not error if the origin header has an upper case first letter" in {
     val accessToken = createAccessToken(UUID.randomUUID().some)
     val inputStream = getInputStream(accessToken, originKey = "Origin")
     val byteArrayCaptor: ArgumentCaptor[Array[Byte]] = ArgumentCaptor.forClass(classOf[Array[Byte]])

--- a/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTestUtils.scala
+++ b/src/test/scala/uk/gov/nationalarchives/signcookies/LambdaTestUtils.scala
@@ -61,11 +61,11 @@ object LambdaTestUtils {
     keycloakMock.getAccessToken(tokenConfig.build())
   }
 
-  def getInputStream(accessToken: String, origin: String = "http://localhost:9000"): ByteArrayInputStream = {
+  def getInputStream(accessToken: String, origin: String = "http://localhost:9000", originKey: String = "origin"): ByteArrayInputStream = {
     val input = s"""{
        |  "headers": {
        |    "Authorization": "Bearer $accessToken",
-       |    "origin": "$origin"
+       |    "$originKey": "$origin"
        |
        |  },
        |  "requestContext": {


### PR DESCRIPTION
Some browsers (Edge) send the origin header as Origin which circe
doesn't like. This will allow either Origin or origin. Hopefully we
won't find an ancient MS browser that likes to send ORIGIN.
